### PR TITLE
Pin rspec to 2.x

### DIFF
--- a/hubspot-ruby.gemspec
+++ b/hubspot-ruby.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   # Add development-only dependencies here
   s.add_development_dependency("rake")
-  s.add_development_dependency("rspec")
+  s.add_development_dependency("rspec", "~> 2.0")
   s.add_development_dependency("rr")
   s.add_development_dependency("webmock", "< 1.10")
   s.add_development_dependency("vcr")


### PR DESCRIPTION
Some tests use rspec-its which is not part of rspec 3. Upgrading to rspec 3 is probably a good idea eventually.